### PR TITLE
Article 21: Règlement Intérieur par le CA

### DIFF
--- a/reglement-interieur.md
+++ b/reglement-interieur.md
@@ -21,34 +21,7 @@ membres à un projet. Cette association est libre et chacun est libre de la refu
 
 Le Conseil d’administration est l’instance qui assure la gestion de l’association au cours de l’année.
 Sa mission et de réunion sont définies par les statuts de l’association. Ses modalités de constitution
-sont définies par le présent règlement intérieur.
-
-#### Élection
-
-L'élection des membres du Conseil d’administration a lieu lors de l'Assemblée Générale Ordinaire.
-
-Toute personne adhérente à l’association depuis plus de six mois, majeure ou mineure de 16 ans, est
-éligible.
-
-Toute personne adhérente à l'association peut participer au vote du Conseil d'administration,
-majeure ou mineure de 16 ans.
-
-L'élection est faite par vote à main levée, à la majorité simple des présents. Le vote est effectué à
-bulletin secret à la demande d’au moins un membre.
-
-Le vote par correspondance ou par procuration est autorisé. Nul ne peut être porteur de plus d’une
-procuration.
-
-Comme défini dans les statuts, devront être élus un minimum de 4 personnes et un maximum de 25
-personnes.
-
-Si le minimum de 4 personnes n'est pas atteint, le vote est annulé et devra être réorganisé lors d'une
-Assemblée Générale Extraordinaire. Si à la suite de ce deuxième vote le minimum de 4 personnes
-n'est pas atteint, l'ancien conseil d'administration devra procéder aux démarches de dissolution de
-l’association.
-
-Si plus de 25 personnes obtiennent la majorité simple, un second tour devra être effectué dans les
-mêmes conditions que le premier vote.
+sont définies dans les statuts de l'association.
 
 #### Charte de fonctionnement du CA
 

--- a/statuts.md
+++ b/statuts.md
@@ -28,7 +28,7 @@ réelles, aidant à la réalisation de l’objet de l’association ;
 entrant dans le cadre de l’objet de l’association ;
 - tout autre moyen décidé par le conseil d’administration
 en accord avec l’objet social de l’association.
-c
+
 **Article 5.** Les ressources de l’association comprennent :
 
 - les cotisations versées par les membres ;

--- a/statuts.md
+++ b/statuts.md
@@ -73,9 +73,21 @@ prochain mandat.
 Le conseil d’administration est élu par l’assemblée
 générale pour un mandat d’un an renouvelable.
 Toute personne adhérente à l’association depuis
-plus de six mois, majeure ou mineure de 16 ans,
-est éligible. Les modalités de l’élection sont fixées
-par le règlement intérieur.
+plus de six mois, majeure ou mineure âgée de 16 ans ou plus,
+est éligible et peut participer au vote du Conseil d'administration.
+
+L'élection est faite par vote à main levée, à la majorité simple des présents. 
+Le vote est effectué à bulletin secret à la demande d’au moins un membre.
+Le vote par correspondance ou par procuration est autorisé. 
+Nul ne peut être porteur de plus d’une procuration.
+
+Si le minimum de 6 personnes n'est pas atteint, le vote est annulé et devra être réorganisé lors d'une
+Assemblée Générale Extraordinaire. Si à la suite de ce deuxième vote le minimum de 6 personnes
+n'est pas atteint, l'ancien conseil d'administration devra procéder aux démarches de dissolution de
+l’association.
+
+Si plus de 25 personnes obtiennent la majorité simple, un second tour devra être effectué dans les
+mêmes conditions que le premier vote.
 
 **Article 9.** Le conseil d’administration est investi
 d’une manière générale des pouvoirs les plus étendus

--- a/statuts.md
+++ b/statuts.md
@@ -28,7 +28,7 @@ réelles, aidant à la réalisation de l’objet de l’association ;
 entrant dans le cadre de l’objet de l’association ;
 - tout autre moyen décidé par le conseil d’administration
 en accord avec l’objet social de l’association.
-
+c
 **Article 5.** Les ressources de l’association comprennent :
 
 - les cotisations versées par les membres ;
@@ -66,7 +66,7 @@ d’administration pour fournir ses explications
 sous quinze jours.
 
 **Article 8.** L’association est administrée par un
-conseil d’administration, composé de 4 à 25 personnes.
+conseil d’administration, composé de 13 à 25 personnes.
 Le nombre est fixé par le conseil pour le
 prochain mandat.
 
@@ -267,7 +267,7 @@ des buts similaires, conformément à l’article
 9 de la loi du 1ier juillet 1901 et au décret du
 16 août 1901.
 
-**Article 21.** L’assemblée générale établit un règlement
+**Article 21.** Le conseil d'administration établit un règlement
 intérieur destiné à fixer les divers points non
 prévus par les présents statuts, notamment ceux
 ayant trait à l’administration interne de l’association.

--- a/statuts.md
+++ b/statuts.md
@@ -66,7 +66,7 @@ d’administration pour fournir ses explications
 sous quinze jours.
 
 **Article 8.** L’association est administrée par un
-conseil d’administration, composé de 13 à 25 personnes.
+conseil d’administration, composé de 6 à 25 personnes.
 Le nombre est fixé par le conseil pour le
 prochain mandat.
 
@@ -267,8 +267,8 @@ des buts similaires, conformément à l’article
 9 de la loi du 1ier juillet 1901 et au décret du
 16 août 1901.
 
-**Article 21.** Le conseil d'administration établit un règlement
-intérieur destiné à fixer les divers points non
+**Article 21.** L’assemblée générale et conseil d'administration 
+établissent un règlement intérieur destiné à fixer les divers points non
 prévus par les présents statuts, notamment ceux
 ayant trait à l’administration interne de l’association.
 

--- a/statuts.md
+++ b/statuts.md
@@ -279,8 +279,9 @@ des buts similaires, conformément à l’article
 9 de la loi du 1ier juillet 1901 et au décret du
 16 août 1901.
 
-**Article 21.** L’assemblée générale et conseil d'administration 
-établissent un règlement intérieur destiné à fixer les divers points non
+**Article 21.** L’assemblée générale établit un règlement intérieur
+destiné à fixer les divers points non
 prévus par les présents statuts, notamment ceux
 ayant trait à l’administration interne de l’association.
-
+L’assemblée générale et le conseil d’administration sont tous deux 
+habilités à modifier le règlement intérieur.


### PR DESCRIPTION
Je propose de changer l'article 21 pour que le CA soit responsable du règlement intérieur.

Cela donne beaucoup de pouvoir au CA mais cela permet de le changer plus rapidement et plus efficacement. C'est un des but du règlement intérieur, être plus souple à changer que les statuts.

En contre partie de ce pouvoir accru au CA je propose de relever le minimum de membres de celui-ci à 13 personnes soit le double de l'équivalent du bureau étendu + 1. Mon idée étant qu'ainsi le bureau seul n'aura pas la capacité à tout contrôler et que cela représente suffisamment de personnes pour limiter les abus.
