### PR TITLE
AGE

### DIFF
--- a/statuts.md
+++ b/statuts.md
@@ -236,17 +236,19 @@ se réunit physiquement sur convocation du président
 ou à la demande de la moitié des membres.
 
 Les conditions de convocation sont identiques à
-celles d’une assemblée générale ordinaire. L’ordre
-du jour est la modification des statuts ou la dissolution
-de l’association.
+celles d’une assemblée générale ordinaire.
 
 L’assemblée générale extraordinaire délibère valablement
-si les deux tiers des membres sont
-présents. Les décisions sont prises à la majorité absolue
-des présents, votées à bulletin secret.
+si les deux tiers des membres sont présents. Les décisions
+sont prises à la majorité simple des présents,
+à main levée. Le vote est effectué à bulletin secret
+à la demande d’au moins un membre.
 
 Le vote par procuration n’est pas autorisé, mais le
 vote par correspondance l’est.
+
+L’assemblée générale extraordinaire n’a pas le pouvoir
+d’en modifier l’ordre du jour.
 
 **Article 19.** Les décisions prises par le conseil
 d’administration et les assemblées générales sont

--- a/statuts.md
+++ b/statuts.md
@@ -232,8 +232,9 @@ procuration.
 
 **Article 18.** L’assemblée générale extraordinaire
 comprend tous les membres de l’association. Elle
-se réunit physiquement sur convocation du président
-ou à la demande de la moitié des membres.
+se réunit, éventuellement électroniquement, sur
+convocation du président ou à la demande de la moitié
+des membres.
 
 Les conditions de convocation sont identiques à
 celles d’une assemblée générale ordinaire.

--- a/statuts.md
+++ b/statuts.md
@@ -222,9 +222,9 @@ et l’ordre du jour.
 
 L’assemblée générale ordinaire délibère valablement
 quelque soit le nombre de présents. Les décisions
-sont prises à la majorité simple des présents,
-à main levée. Le vote est effectué à bulletin secret
-à la demande d’au moins un membre.
+sont prises à la majorité simple des votes exprimés.
+Le vote est effectué à bulletin secret à la demande
+d’au moins un membre.
 
 Le vote par correspondance ou par procuration est
 autorisé. Nul ne peut être porteur de plus d’une
@@ -240,9 +240,9 @@ celles d’une assemblée générale ordinaire.
 
 L’assemblée générale extraordinaire délibère valablement
 si les deux tiers des membres sont présents. Les décisions
-sont prises à la majorité simple des présents,
-à main levée. Le vote est effectué à bulletin secret
-à la demande d’au moins un membre.
+sont prises à la majorité simple des votes exprimés.
+Le vote est effectué à bulletin secret à la demande
+d’au moins un membre.
 
 Le vote par procuration n’est pas autorisé, mais le
 vote par correspondance l’est.

--- a/statuts.md
+++ b/statuts.md
@@ -233,7 +233,7 @@ procuration.
 **Article 18.** L’assemblée générale extraordinaire
 comprend tous les membres de l’association. Elle
 se réunit, éventuellement électroniquement, sur
-convocation du président ou à la demande de la moitié
+convocation du président ou à la demande de la moitié au moins
 des membres.
 
 Les conditions de convocation sont identiques à
@@ -274,4 +274,3 @@ des buts similaires, conformément à l’article
 intérieur destiné à fixer les divers points non
 prévus par les présents statuts, notamment ceux
 ayant trait à l’administration interne de l’association.
-


### PR DESCRIPTION
Quelques suggestions :
1. Il est parfois nécessaire de prendre des décisions importantes sans attendre l'AGO suivante. Il me semble donc profitable d'enlever la restriction de l'ordre du jour de l'AGE.
2. Comme les conditions de convocations sont identiques à celles de l'AGO, la convocation doit être accompagnée de l'ordre du jour.
3. Une AGE autorisée à modifier son propre ordre du jour par le biais d'un vote équivaudrait à donner les pleins pouvoirs aux membres présents, ce qui est dangereux. (Les membres absents ont peut-être simplement décidé de s'abstenir une fois l'ordre du jour connu.)
4. Je vois pas de raison d'appliquer, dans ces conditions, le vote à bulletin secret de façon systématique pour toute décision de l'AGE.
5. Actuellement les votes par correspondances (et par procuration à l'AGO) ne sont pas pris en compte puisque les décisions sont prises à la majorité des présents et que nulle part on indique que sont comptés présents les gens qui votent par procuration ou par correspondance. Pour résoudre ceci, on peut parler des votes exprimés. La validité des votes est déjà couverte (être membre, être présent ou procuration ou correspondance, ou pas de procuration, etc).
6. Je vois pas l'intérêt de préciser qu'il s'agit de vote à main levée. L'important c'est que le vote ait lieu, pas qu'il se fasse à bulletin ouvert, secret, main levée, acclamation ou autre. Aussi, vote par correspondance ou par procuration sont difficiles à concilier avec main levée.
7. Dans le cas de l'AGE j'ai remplacé majorité absolue par majorité simple. C'est un peu technique mais dans 99% des cas ça ne changera rien. L'idée est que presque chaque vote est "pour/contre", du coup majorité absolue ou majorité simple revient exactement au même. Par contre vu que je propose que l'AGE puisse avoir un ordre du jour arbitraire (par exemple s'il est nécessaire d'y procéder à une élection), la majorité absolue est un peu pénible à mettre en place.
