### PR TITLE
Ajoute les documents publics relatifs aux AG et réunions CA

### DIFF
--- a/2014/2014-03-15_PV_AGC.md
+++ b/2014/2014-03-15_PV_AGC.md
@@ -1,0 +1,80 @@
+*Association Zeste de Savoir*
+
+*9 rue Jean Yole, Appt 6 - 85260 L'Hébergement - France*
+
+# Procès-verbal de l’Assemblée Générale constitutive du 15 mars 2014
+
+Le 15 mars 2014 à 17 heures, les fondateurs de l’association Zeste de Savoir se sont réunis en assemblée générale constitutive chez Geoffrey Royer, 201 rue de Vaugirard 75015 Paris.
+
+Étaient présentes les personnes suivantes :
+
+- **Matthieu Bonan**, nationalité Française, 35 impasse de Prague Appt 201 59800 Lille - France ;
+- **Baptiste Clavié**, nationalité Française, 3 rue le verrier 75006 Paris - France ;
+- **François Colin**, nationalité Française, 6 place du 11 novembre 1918 92300 Levallois-Perret- France ;
+- **Alexandre Demode**, nationalité Française, 295 rue des Hurteaux 60400 Varesnes - France ;
+- **Christian Dreher**, nationalité Française, 28 rue Jules Guesde Appt 19 92300 Levallois-Perret - France ;
+- **Christophe Gabard**, nationalité Française, l’adresse sera renseignée ultérieurement ;
+- **Chantal Gribaumont**, nationalité Belge, 34 Rue de Thibermont 1461 Haut-Ittre - Belgique ;
+- **Willy Konguem**, nationalité Camerounaise, Apt 333 Batiment C 4 bis cours du buisson 77186 Noisiel - France ;
+- **Adrien Morison**, nationalité Française, 17 ter bld Carnot 42600 Montbrison - France ;
+- **Gérard Paligot**, nationalité Belge, 13 Rue Louis Aragon 59790 Ronchin Lille - France ;
+- **David Roux**, nationalité Française, 165 rue Jean-Pierre Timbaud 92400 Courbevoie - France ;
+- **Geoffrey Royer**, nationalité Française, 201 rue de Vaugirard 75015 Paris - France ;
+- **Gautier Szukala**, nationalité Française, 910 rue du Molinel 59310 Coutiches - France ;
+- **Sébastien Trutié de Vaucresson**, nationalité Française, 9 rue Jean Yole - Appt 6 85260 L'Hébergement - France.
+
+L’assemblée générale désigne Sébastien Trutié de Vaucresson en qualité de président de séance et David Roux en qualité de secrétaire de séance.
+
+Le président de séance met à la disposition des présents le projet de statuts de l’association et l’état des actes passés pour le compte de l’association en formation. Puis il rappelle que l’assemblée générale constitutive est appelée à statuer sur l’ordre du jour suivant :
+
+- présentation du projet de constitution de l’association ;
+- présentation du projet de statuts et du règlement intérieur ;
+- adoption des statuts et du règlement intérieur ;
+- désignation des premiers membres du conseil ;
+- reprises des actes passés pour le compte de l’association en formation;
+- pouvoirs en vue des formalités de déclaration et publication.
+
+Enfin, le président expose les motifs du projet de création de l’association et commente le projet de statuts. Après débat, le président met successivement aux voix les délibérations suivantes :
+
+## 1 ère délibération
+
+L’assemblée générale adopte les statuts ainsi que le Règlement Intérieur dont le projet lui a été soumis.
+
+Cette délibération est adoptée à l’unanimité.
+
+## 2 ème délibération
+
+L’assemblée générale constitutive désigne à l’unanimité les personnes suivantes en tant que membres du conseil :
+
+- **Matthieu Bonan**, nationalité Française, 35 impasse de Prague Appt 201 59800 Lille - France
+- **Baptiste Clavié**, nationalité Française, 3 rue le verrier 75006 Paris - France
+- **François Colin**, nationalité Française, 6 place du 11 novembre 1918 92300 Levallois-Perret - France
+- **Alexandre Demode**, nationalité Française, 295 rue des Hurteaux 60400 Varesnes - France
+- **Christian Dreher**, nationalité Française, 28 rue Jules Guesde Appt 19 92300 Levallois-Perret - France
+- **Christophe Gabard**, nationalité Française, l’adresse sera renseignée ultérieurement
+- **Chantal Gribaumont**, nationalité Belge, 34 Rue de Thibermont 1461 Haut-Ittre - Belgique
+- **Willy Konguem**, nationalité Camerounaise, Apt 333 Batiment C 4 bis cours du buisson 77186 Noisiel - France
+- **Adrien Morison**, nationalité Française, 17 ter bld Carnot 42600 Montbrison - France
+- **Gérard Paligot**, nationalité Belge, 13 Rue Louis Aragon 59790 Ronchin Lille - France
+- **David Roux**, nationalité Française, 165 rue Jean-Pierre Timbaud 92400 Courbevoie - France
+- **Geoffrey Royer**, nationalité Française, 201 rue de Vaugirard 75015 Paris - France
+- **Gautier Szukala**, nationalité Française, 910 rue du Molinel 59310 Coutiches - France
+- **Sébastien Trutié de Vaucresson**, nationalité Française, 9 rue Jean Yole - Appt 6 85260 L'Hébergement - France
+
+## 3 ème délibération
+
+Après débat, l’assemblée désigne François Colin pour organiser une réflexion sur la transmission des droits patrimoniaux de la propriété intellectuelle du site Web de Zeste de Savoir.
+
+## Actes passés
+
+Des noms de domaine (pour une valeur de 87,16€ TTC) ainsi qu’un VPS (pour une valeur de 114,67€ TTC) ont été apportés par Gauthier Szukala à l’association.
+
+Le code source du site Web Zeste de Savoir ainsi que sa charte graphique et le logo du site sont amenés à être intégrés à l’association une fois que les questions de licence et de propriété intellectuelle auront été traitées (voir la 3 ème délibération).
+
+L'Assemblée Générale constitutive donne pouvoir à Sébastien Trutié de Vaucresson aux fins d'effectuer toutes démarches nécessaires à la constitution de l'association (déclaration à la préfecture et publication au Journal Officiel). Cette résolution est adoptée à l'unanimité.
+
+---
+
+Il est dressé le présent procès-verbal de l'Assemblée Générale constitutive.
+
+*Date et signature du Président de séance et du Secrétaire de séance*

--- a/2014/2014-03-15_PV_RCA.md
+++ b/2014/2014-03-15_PV_RCA.md
@@ -1,0 +1,53 @@
+*Association Zeste de Savoir*
+
+*9 rue Jean Yole, Appt 6 - 85260 L'Hébergement - France*
+
+## Procès-verbal de la réunion du Conseil du 15 mars 2014
+
+Le 15 mars 2014 à 19 heures, le conseil de Zeste de Savoir s’est réuni chez Geoffrey Royer, 201 rue de Vaugirard 75015 Paris.
+
+Étaient présentes les personnes suivantes :
+
+- **Matthieu Bonan**, nationalité Française, 35 impasse de Prague Appt 201 59800 Lille - France
+- **Baptiste Clavié**, nationalité Française, 3 rue le verrier 75006 Paris - France
+- **François Colin**, nationalité Française, 6 place du 11 novembre 1918 92300 Levallois-Perret - France
+- **Alexandre Demode**, nationalité Française, 295 rue des Hurteaux 60400 Varesnes - France
+- **Christian Dreher**, nationalité Française, 28 rue Jules Guesde Appt 19 92300 Levallois-Perret - France
+- **Christophe Gabard**, nationalité Française, l’adresse sera renseignée ultérieurement
+- **Chantal Gribaumont**, nationalité Belge, 34 Rue de Thibermont 1461 Haut-Ittre - Belgique
+- **Willy Konguem**, nationalité Camerounaise, Apt 333 Batiment C 4 bis cours du buisson 77186 Noisiel - France
+- **Adrien Morison**, nationalité Française, 17 ter bld Carnot 42600 Montbrison - France
+- **Gérard Paligot**, nationalité Belge, 13 Rue Louis Aragon 59790 Ronchin Lille - France
+- **David Roux**, nationalité Française, 165 rue Jean-Pierre Timbaud 92400 Courbevoie - France
+- **Geoffrey Royer**, nationalité Française, 201 rue de Vaugirard 75015 Paris - France
+- **Sébastien Trutié de Vaucresson**, nationalité Française, 9 rue Jean Yole - Appt 6 85260 L'Hébergement - France
+
+Le conseil désigne Sébastien Trutié de Vaucresson en qualité de président de séance et David Roux en qualité de secrétaire de séance.
+
+Le président de séance rappelle que le conseil est appelé à statuer sur l’ordre du jour suivant :
+
+1. Élection du Bureau
+2. Remboursement des frais avancés par Gauthier Szukala au titre des actes passés
+3. Fixation du montant de la cotisation annuelle
+
+## 1 ère délibération
+
+Le conseil élit les membres du bureau
+
+- **Président** : Sébastien Trutié de Vaucresson, nationalité Française, 9 rue Jean Yole, Appt 6 - 85260 L'Hébergement - France
+- **Trésorier** : Christian Dreher, nationalité Française, 28 rue Jules Guesde Appt 19 - 92300 Levallois-Perret - France
+- **Secrétaire** : David Roux, nationalité Française, 165 rue Jean-Pierre Timbaud - 92400 Courbevoie - France
+
+## 2 ème délibération
+
+Des noms de domaine (pour une valeur de 87,16€ TTC) ainsi qu’un VPS (pour une valeur de 114,67€ TTC) ont été apportés par Gauthier Szukala à l’association. Ces montants seront remboursés à Gauthier Szukala dès réception des documents attestant ces achats.
+
+## 3 ème délibération
+
+Le conseil fixe la cotisation annuelle à 30€ par an.
+
+---
+
+Il est dressé le présent procès-verbal de la réunion du conseil de Zeste de Savoir.
+
+*Date et signature du Président de séance et du Secrétaire de séance*

--- a/2014/2014-03-15_convoc_AGC.md
+++ b/2014/2014-03-15_convoc_AGC.md
@@ -1,0 +1,28 @@
+*L'Herbergement, le 11 mars 2014*
+
+*Sébastien TRUTIÉ de VAUCRESSON - 9 rue Jean Yole, Appt 06 - 85260 L'Herbergement*
+
+**Objet : Convocation à l’assemblée générale constitutive de l’association « Zeste de Savoir »**
+
+Madame, Monsieur,
+
+J’ai l’honneur de vous inviter à l’assemblée générale constitutive de l’association dont la constitution est envisagée, qui aura lieu le 15 mars 2014 à 17 heures à l'adresse suivante :
+
+*ROYER Geoffrey - 201 Rue de Vaugirard - 75015 Paris*
+
+pour délibérer sur l’ordre du jour suivant :
+
+- présentation du projet de constitution de l’association ;
+- présentation du projet de statuts et de règlement intérieur;
+- adoption des statuts du règlement intérieur ;
+- désignation des premiers membres du conseil d’administration ;
+- reprise des actes passés pour le compte de l’association en formation ;
+- pouvoirs en vue des formalités de déclaration et de publication.
+
+Votre présence à cette assemblée est nécessaire et, en cas d’empêchement, vous pouvez vous faire représenter par un mandataire de votre choix, muni d’un pouvoir.
+
+Les premiers membres du conseil nommés par l’assemblée générale constitutive seront convoqués à la première réunion de ce conseil, qui se tiendra à l’issue de cette assemblée, pour procéder à la désignation des membres du bureau : président, vice-président, trésorier et secrétaire.
+
+Cordialement, avec mes salutations associatives.
+
+*Sébastien Trutié de Vaucresson*

--- a/2014/2014-05-05_PV_RCA.md
+++ b/2014/2014-05-05_PV_RCA.md
@@ -1,0 +1,56 @@
+*Association Zeste de Savoir*
+
+*9 rue Jean Yole, Appt 6 - 85260 L'Hébergement - France*
+
+# Procès-verbal de la réunion du conseil d’Administration du 5 mai 2014
+
+Le 5 mai 2014 à 21 heures, le Conseil d’Administration de l’association Zeste de Savoir s’est réuni électroniquement.
+
+Étaient présentes les personnes suivantes :
+
+- Sébastien Trutié de Vaucresson, Président de l’association
+- Christian Dreher, Trésorier de l’association
+- David Roux, Secrétaire de l’association
+- Matthieu Bonan
+- Alexandre Demode
+- Chantal Gribaumont
+- Willy Konguem
+- Gérard Paligot
+- Geoffrey Royer
+
+Ne pouvant être présent, Christophe Gabard a donné procuration à Willy Konguem.
+
+Avec 9 membres + 1 procuration sur les 14 personnes constituant le Conseil d’Administration, le quorum est atteint.
+
+Le Conseil d’Administration était présidé par Sébastien Trutié de Vaucresson en qualité de Président de l’association. Il était assisté par David Roux en qualité de Secrétaire.
+
+Le président de séance met à la disposition des présents l’ordre du jour suivant :
+
+1. Choix des mandataires pour l’ouverture du compte en banque de l’association ;
+2. Choix des mandataires pour la gestion du compte en banque de l’association ;
+3. Choix de la personne chargée de souscrire l’assurance de l’association
+4. Choix de la personne chargée de faire les démarches auprès de la CNIL pour le site zestedesavoir.com et l’association ainsi que de mettre à jour les CGU du site en conséquence.
+
+Après débat, le président met successivement aux voix les délibérations suivantes :
+
+## 1 ère délibération
+
+Le Conseil d’Administration désigne à l’unanimité Sébastien Trutié de Vaucresson et Christian Dreher comme mandataires pour l’ouverture du compte bancaire de l’association.
+
+## 2 ème délibération
+
+Le Conseil d’Administration désigne à l’unanimité Sébastien Trutié de Vaucresson et Christian Dreher comme mandataires pour la gestion du compte bancaire de l’association.
+
+## 3 ème délibération
+
+Le Conseil d’Administration désigne à l’unanimité Christian Dreher pour la souscription de l’assurance de l’association.
+
+## 4 ème délibération
+
+Le Conseil d’Administration désigne à l’unanimité David Roux pour effectuer auprès de la CNIL les démarches administratives relatives au site zestedesavoir.com que de mettre à jour les CGU du site en conséquence.
+
+---
+
+Il est dressé le présent procès-verbal de la réunion du Conseil d’Administration de Zeste de Savoir.
+
+*Date et signature du Président de séance et du Secrétaire de séance*

--- a/2015/2015-04-11_PV_AGO.md
+++ b/2015/2015-04-11_PV_AGO.md
@@ -1,0 +1,162 @@
+*Association Zeste de Savoir*
+
+*9 rue Jean Yole, Appt 6 - 85260 L'Hébergement - France*
+
+# Procès-verbal de l'Assemblée Générale constitutive du 11 avril 2015
+
+Le 11 avril 2015 à 19h15 heures, les membres de l'association Zeste de Savoir se sont réunis en Assemblée Générale ordinaire dans les locaux de l’AGECA, 177 rue de Charonne 75011 Paris.
+
+Étaient présentes les personnes suivantes
+
+- Sébastien Trutié de Vaucresson, Président ;
+- Christian Dreher, Trésorier ;
+- David Roux, Secrétaire ;
+- Loup Balleyguier ;
+- Alexis Cadoret ;
+- Arnaud Calmettes ;
+- Florant Chapelle (via Hangouts) ;
+- François Colin ;
+- François Dambrine (via Hangouts) ;
+- Nicolas Dessart ;
+- Victor Felder (via Hangouts) ;
+- Christophe Gabard ;
+- Chantal Gribaumont ;
+- Willy Konguem ;
+- Simon Landrault (via Hangouts) ;
+- Adrien Morison (via Hangouts) ;
+- Gérard Paligot (via Hangouts) ;
+- Geoffrey Royer.
+
+Procurations
+
+- Matthieu Bonan a donné procuration à Christophe Gabard ;
+- Baptiste Clavié a donné procuration à Willy Konguem ;
+- Médéric Munier a donné procuration à François Colin ;
+- Gautier Szukala a donné procuration à Sébastien Trutié de Vaucresson.
+
+Sébastien Trutié de Vaucresson préside la séance. David Roux est le secrétaire de séance.
+
+Après les salutations d’usage, le Président rappelle que l’Assemblée Générale constitutive est appelée à statuer sur l’ordre du jour suivant:
+
+1. Rapport d'activité ;
+2. Bilan moral du Président ;
+3. Bilan financier ;
+4. Bilan des commissions ;
+5. Vote de la cotisation pour l'année 2015 ;
+6. Modification des statuts et du règlement intérieur ;
+7. Élection du nouveau Conseil d’Administration (CA).
+
+## Rapport d'activité
+
+Le Président, avec l'aide de François Colin présentent les chiffres relatifs au site Web Zeste de Savoir. Les chiffres sont bons et en progression constante malgré un creux en octobre 2014. C'est en grande partie une reprise de l’article publié sur le site pour célébrer les 2000 membres.
+
+Du point de vue de la validation des tutoriels, 28 sont en attente dont la moitié de Mewtow. Le staff du site a décidé d'alterner les publications afin de varier le contenu présent sur la page d'accueil.
+
+L’équipe de communication est félicitée pour son bon travail bien que l’on remarque que peu de personnes parlent du site en dehors des communiqués officiels. Cet état est imputé à la relative
+jeunesse du site.
+
+Les membres du staff du site font la remarque que la communauté est très agréable et arrive à s'autogérer. Très peu de bannis qui le sont, pour la plupart, pour des raisons de publicité non autorisée.
+
+Le rapport d’activité est adopté à l'unanimité.
+
+## Bilan moral du Président
+
+La seule activité significative de l'association a été l’ouverture de celle-ci et les démarches administratives qui ont suivies (compte en banque, assurance...).
+
+Il est remarqué que le CA a très peu agis vis-à-vis du site car, comme mentionné auparavant, la communauté se gère toute seule. Et ce, même sur les sujets importants tels que la potentielle mise en place de Google Ad-Words qui a pour le moment été refusée. Les membres présents décident de mettre le sujet de la publicité de côté.
+
+David Roux demande où en est le transfert des noms de domaine à l’association. Le Président répond que le processus est en cours mais prend du temps.
+
+Une discussion est engagée à propos de l'utilité d’avoir un forum Staff et un forum CA séparés. Il est décidé de garder ce schéma car cela marche bien.
+
+Ensuite, plusieurs pistes de diversification sont évoquées :
+
+- Participation à des conférences et évènements extérieurs à l’association : oui si invité car difficile à assurer seul avec notre budget actuel ;
+- Production de goodies : flyers, t-shirts... Il est encore trop tôt pour démarrer ce genre d'activité mais l’idée est intéressante ;
+- Intervenir dans des établissements scolaires afin de faire un exposé sur une thématique précise auprès des élèves. Proposition accueillie avec enthousiasme sous réserve de trouver des personnes motivées pour participer à ce genre d’évènement.
+
+Par la suite, le statut des serveurs de pré-prod et de sauvegarde, qui sont actuellement extérieurs à l'association est évoqué. Il est décidé que le nouveau CA devra se réunir d’ici un mois pour en
+discuter.
+
+Le Président conclus enfin par le fait qu’il est important de rester concentré sur la vie du site Web qui reste l’objectif principal de l’association.
+
+Le bilan moral est adopté à l'unanimité.
+
+## Bilan financier
+
+Christian Dreher présente le bilan financier de l'association. Celle-ci est bénéficiaire, à la date de l’Assemblée Générale de 360,64€. Montant auquel il faudra soustraire les 92€ pour la location de la salle au sein de laquelle se déroule la présente AG. Ce qui laisse 268,64€ d’excédent.
+
+Une hausse du budget concernant les serveurs est à prévoir car le serveur de pré-prod et de sauvegarde seront sans doute intégré au sein de l'association.
+
+Le Secrétaire fait remarquer qu’en 2014, l'association comptait 31 membres dont 30 cotisants car le dernier arrivant a été exceptionnellement exempté de cotisation par le CA du fait qu'il ait rejoint l’association le mois précédent la présente AG.
+
+Le bilan financier est adopté à l’unanimité moins une abstention.
+
+## Bilan des commissions
+
+### Le poste de directeur technique
+
+François Colin et Arnaud Calmettes ont occupé ce poste lors de l’année écoulée. Pour rappel, le directeur technique est le garant des choix techniques et technologiques du site Zeste de Savoir.
+
+François Colin rappelle que le dépôt GitHub du site comporte plus de 4300 commits, ce qui en fait un des sites parmi les 2% les plus actifs selon le site OpenHub.
+
+François Colin remarque que le rôle de directeur technique est très bien compris par les contributeurs du site. Par contre, le projet étant open-source, certains points liés au site n'avancent pas du fait que les contributeurs participent sur leur temps libre. Le besoin d'un chef de projet se fait donc sentir ainsi qu’une doublure pour le directeur technique en cas d'indisponibilité de ce dernier.
+
+L'assemblée décide à l'unanimité que le CA devra se pencher sur ce sujet.
+
+### La communication
+
+Chantal Gribaumont présente son rapport pour l’année écoulée.
+
+En dehors du site, la communication de l’association passe par les réseaux sociaux (Facebook, Google+ et Twitter), les mails, les échanges avec les auteurs de tutoriels extérieurs au site...
+
+Chantal remarque que le besoin de communication sur le site lui-même est très faible car ces sujets sont traités parla communauté elle-même. Idem pour l'animation des forums.
+
+L'équipe de communication ne prévoit pas de recrutement pour le moment.
+
+L'idée d'intégrer le compte Buffer (programmation de publication sur les réseaux sociaux) au sein de l’association est laissée aux bons soins du CA.
+
+## Cotisation
+
+Après diverses discussions en lien avec le bilan financier et les prochaines évolutions à venir, l’Assemblée Générale décide à l'unanimité de fixer le montant de la cotisation pour l'année 2015 à 20€ par membre.
+
+## Modification des statuts et du règlement intérieur
+
+Les modalités pour réunir une Assemblée Générale extraordinaire étant trop strictes, l'Assemblée Générale adopte à l’unanimité les changements suivants :
+
+- Présence par voie électronique autorisée ;
+- Procurations autorisées.
+
+## Élection du Conseil d’Administration
+
+Après consultation des membres présents, se représentent au Conseil d’Administration les personnes suivantes :
+
+- Matthieu Bonan ;
+- Baptiste Clavié ;
+- François Colin ;
+- Christian Dreher ;
+- Christophe Gabard ;
+- Chantal Gribaumont ;
+- Willy Konguem ;
+- Adrien Morison ;
+- Gérard Paligot ;
+- David Roux ;
+- Geoffrey Royer ;
+- Gautier Szukala ;
+- Sébastien Trutié de Vaucresson.
+
+Se présentent pour la première fois :
+
+- Arnaud Calmettes ;
+- Florent Chapelle ;
+- Simon Landrault.
+
+L'Assemblée Générale élit à l’unanimité les membres sortants et les nouveaux postulants.
+
+---
+
+Il est dressé le présent procès-verbal de l'Assemblée Générale ordinaire.
+
+*Sébastien Trutié de Vaucresson, Président de Zeste de Savoir*
+
+*David Roux, Secrétaire de Zeste de Savoir*

--- a/2015/2015-04-11_PV_RCA.md
+++ b/2015/2015-04-11_PV_RCA.md
@@ -1,0 +1,40 @@
+*Association Zeste de Savoir*
+
+*9 rue Jean Yole, Appt 6 - 85260 L'Hebergement - France*
+
+# Procès verbal de la réunion du Conseil du 11 avril 2015
+
+Le 11 avril 2015 à 22h15, le conseil de Zeste de Savoir s'est réuni dans les locaux de l'AGECA, 177 rue de Charonne, Paris.
+
+Étaient présentes les personnes suivantes :
+
+- Arnaud Calmettes ;
+- Florent Chapelle ;
+- François Colin ;
+- Christian Dreher ;
+- Christophe Gabard ;
+- Chantal Gribaumont ;
+- Willy Konguem ;
+- Simon Landrault ;
+- Adrien Morison ;
+- Gérard Paligot ;
+- David Roux ;
+- Geoffrey Royer ;
+- Sébastien Trutié de Vaucresson
+
+Le conseil désigne Sébastien Trutié de Vaucresson en qualité de président de scéance et David Roux en qualité de secrétaire de scéance.
+
+Le président de scéance rappelle que le conseil est appelé à statuer sur l'ordre de jour suivant :
+
+- Élection du Bureau ;
+- Questions diverses.
+
+## 1ère délibération
+
+Le conseil décide de demander aux contributeurs du site Zeste de Savoir d'ajouter un champ permetant de saisir son numéro de téléphone afin d'avoir un nouveau moyen de contacter les membres. La saisie de ce champ sera optionnelle.
+
+Il est dressé le présent procès verbal du conseil de Zeste de Savoir.
+
+*Sébastion Trutié de Vaucresson, Président de Zeste de Savoir*
+
+*David Roux, Secrétaire de Zeste de Savoir*

--- a/2015/2015-04-11_convoc_AGO.md
+++ b/2015/2015-04-11_convoc_AGO.md
@@ -1,0 +1,31 @@
+*Zeste de Savoir*
+
+*9 rue Jean Yole, Appt 06 - 85260 L'Herbergement*
+
+*A L'Herbergement, le 25/03/2015*
+
+Madame, Monsieur,
+
+Nous avons l'honneur de vous informer qu'une assemblée générale ordinaire de l'association Zeste de Savoir aura lieu le 11 avril 2015, à 19 heures 15, dans le bâtiment de l'AGECA, 177 rue de Charonne 75011 Paris.
+
+L'ordre du jour sera le suivant :
+
+1. Rapport d'activité
+2. Bilan moral du Président
+3. Bilan financier du Trésorier
+4. Bilan des commissions
+5. Fixation du montant des cotisations
+6. Modification des statuts et du règlement intérieur
+7. Renouvellement des membres du conseil d'administration
+8. Questions diverses
+
+Nous vous rappelons qu'en vertu des dispositions de nos statuts et de notre règlement intérieur :
+
+- Pour avoir le droit de participer à l'assemblée, vous devez être à jour de cotisation à la date du 11 avril 2015.
+- Si vous ne pouvez pas assister personnellement à l'assemblée générale, vous pouvez vous y faire représenter par un mandataire. A cet effet, vous trouverez ci-joint une formule de pouvoir que vous voudrez bien, après l'avoir complétée et signée, remettre à votre mandataire ou retourner au siège social ou encore par email au secrétaire de l'association. Tous les pouvoirs doivent, aux fins de comptabilisation, être déposés au siège de l'association au plus tard le 10 avril 2015. A défaut, ils ne seront pas pris en compte.
+- Vous pouvez si vous le souhaitez participer à l'assemblée générale par webcam. La vidéoconférence se fera
+via Hangout de Google, vous devrez ajouter l'adresse zestedesavoir@gmail.com dans vos contacts pour pouvoir y participer (merci de prévenir par avance pour pouvoir vous inclure dans la vidéoconférence).
+
+Cordialement, avec mes salutations associatives.
+
+*Sébastien Trutié de Vaucresson*

--- a/2016/2016-04-16_PV_AGO.md
+++ b/2016/2016-04-16_PV_AGO.md
@@ -1,0 +1,161 @@
+*Association Zeste de Savoir*
+
+*9 rue Jean Yole, Appt 6 - 85260 L'Hébergement - France*
+
+# Procès-verbal de l’Assemblée Générale Ordinaire du 16 avril 2016
+
+Le 16 avril 2015 à 15h, les membres de l’association Zeste de Savoir se sont réunis en Assemblée Générale ordinaire (AGO) dans les locaux de PRINE - Paris Région Innovation Nord Express, 48 Rue René Clair, 75018 Paris
+
+Étaient présentes les personnes suivantes :
+
+- David Roux, Secrétaire ;
+- Mehdi Benharrats ;
+- Matthieu Bonan ;
+- Guillaume Boucher ;
+- Arnaud Calmettes ;
+- Florent Chapelle (via Hangouts) ;
+- Baptiste Clavié ;
+- François Colin ;
+- Hugo Courtecuisse ;
+- François Dambrine (via Hangouts) ;
+- Augustin Favin-Lévêque ;
+- Victor Felder (via Hangouts) ;
+- Christophe Gabard ;
+- Quentin Gliech (via hangouts) ;
+- Willy Konguem ;
+- Augustin Laville (via Hangouts) ;
+- Adrien Morison (via Hangouts) ;
+- Gérard Paligot (via Hangouts) ;
+- François Thiré.
+
+Procurations :
+
+- Geoffrey Royer a donné procuration à Victor Felder ;
+- Gautier Szukala a donné procuration à Matthieu Bonan
+
+David Roux préside et est le secrétaire de séance.
+
+Après les salutations d’usage, le président de séance rappelle que l’Assemblée Générale Ordinaire est appelée à statuer sur l’ordre du jour suivant :
+
+1. Rapport d'activité de l’association ;
+2. Bilan moral du Président ;
+3. Bilan financier du Trésorier ;
+4. Modification des statuts et du règlement intérieur ;
+5. Fixation du montant des cotisations ;
+6. Renouvellement des membres du Conseil d'Administration ;
+7. Questions diverses.
+
+## Bilan moral du Président
+
+Le Président de l’association, Sébastien Tuitié de Vaucresson n’étant pas présent, il n’y a pas eu de bilan moral.
+
+## Bilan financier
+
+Christian Dreher n’étant pas présent, il n’y a pas eu de bilan financier
+
+## Rapport d’activité
+
+En conséquence de l’absence du Président et du Trésorier sera fait après l’AGO par le Conseil d’Administration (CA) une fois que le nouveau Bureau aura récupéré tous les documents et accès aux comptes de l’association. De même pour la fixation du montant de la cotisation pour l’année 2016.
+
+Cette décision est adoptée à l’unanimité.
+
+François Colin présente les chiffres relatifs au site Web Zeste de Savoir. Les chiffres sont bons et en progression constante malgré une stagnation depuis le début de l’année. Le site Web compte quelques 4400 membres inscrits et validés (c’est-à-dire hors bannis, robots...).
+
+Les membres du staff du site font la remarque que la communauté est très agréable et dynamique même si il faut que le staff canalise un peu plus certains membres.
+
+Le rapport d’activité est adopté à l’unanimité.
+
+## Bilan des commissions
+
+### Le poste de directeur technique
+
+François Colin rapporte qu’OVH est très inconsistant dans la qualité du service rendu. Cette instabilité s’accroit depuis quelques mois. Il fait remarquer qu’il est urgent que l’association trouve un nouvel hébergeur.
+
+La piste principale étant de passer chez Gandi qui, dans un mail, accepte d’intégrer Zeste de Savoir dans son programme de soutien aux associations. L’association devra leur répondre pour exprimer ses
+besoins.
+
+Actuellement, les serveurs se répartissent ainsi :
+
+- OVH au nom de l’association : production et beta
+- Hébergés par des membres : sauvegarde et monitoring
+
+Il est noté qu’il faudrait trouver un autre administrateur système afin de suppléer l’actuel.
+
+L’assemblée décide à l’unanimité que le CA devra se pencher sur ces sujets.
+
+### La communication
+
+Matthieu Bonan fait remarquer qu’il faudrait ouvrir à plus de personnes de l’association la boite mail de contact.
+
+L’AGO en prend note.
+
+## Cotisation
+
+Elle sera fixée a posteriori par le CA comme expliqué dans la partie « Rapport d’activité ».
+
+## Modification des statuts et du règlement intérieur
+
+La modification du Règlement Intérieur passe par un travail collaboratif disponible sur Github. Les modifications du RI sont disponibles sous forme de Pull Requests (PR) qui seront mergées si votées par l’AGO.
+
+Les modifications proposées sont les suivantes :
+
+- Donner le droit au CA de modifier le RI
+- Passage du Bureau à six membres en dédoublant les postes afin d’éviter que le problème de la disparition du Président et du Trésorier ne se reproduise.
+- Rendre publics les documents relatifs à l’association si ces derniers ne comportent pas d’informations confidentielles ou portant atteinte à la vie privée.
+- Aligner les modalités d’organisations et de déroulement des assemblées Générales Extraordinaires sur celles des AGO.
+- Éclaircissement de la définition de « propos discriminatoires »
+- Ajouter que l’association ne s’associera pas à des personnes morales ou physiques qui prônent la restriction à l’accès à l’information.
+
+Les modifications du RI sont adoptées à l’unanimité.
+
+Par conséquent, les démarches suivantes doivent être entreprises :
+
+- Mettre en place un partage des documents relatifs à l’association.
+- Changer la domiciliation du siège de l’association pour une maison des associations.
+- Mettre en place les modifications du RI.
+
+## Questions diverses
+
+### Rôle du CA
+
+Il est noté que la CA a eu jusqu’à présent un rôle passif au sein du site Web. Afin que ses membres soient plus actifs, il est proposé que les membres du CA organisent et prennent en charge les débats au sein de la communauté. Le CA DOIT s’impliquer dans la vie du site.
+
+En cas de besoin d’être identifié en tant que tel, notamment pour passer des annonces officielles, il est proposé de créer un compte générique CA dont l’accès sera donné à tous les membres constituant celui-ci.
+
+La proposition « trouver un moyen pour le CA de participer aux débats et à la vie du site » est adoptée à l’unanimité.
+
+### Participer à un évènement en dehors du site.
+
+Il est proposé que l’association prenne part à un ou plusieurs évènements extérieurs afin de promouvoir le site, l’association, les contenus qu’elle propose ainsi que ses valeurs.
+
+Cette proposition est adoptée à l’unanimité.
+
+## Élection du Conseil d’Administration
+
+Après consultation des membres présents, se représentent au Conseil d’Administration les personnes suivantes :
+
+- Matthieu Bonan
+- Arnaud Calmettes
+- Florent Chapelle
+- Baptiste Clavié
+- François Colin
+- Christophe Gabard
+- Willy Konguem-
+- Adrien Morison
+- Gérard Paligot
+- David Roux
+- Gautier Szukala
+
+Se présentent pour la première fois :
+
+- Victor Felder
+- Augustin Laville
+- François Thiré
+
+L’Assemblée Générale Ordinaire élit à l’unanimité les membres sortants et les nouveaux postulants.
+
+---
+
+Il est dressé le présent procès-verbal de l'Assemblée Générale Ordinaire.
+
+*David Roux - Secrétaire de Zeste de Savoir*

--- a/2016/2016-04-16_PV_RCA.md
+++ b/2016/2016-04-16_PV_RCA.md
@@ -1,0 +1,61 @@
+*Association Zeste de Savoir*
+
+*9 rue Jean Yole - Appt 6 - 85260 L'Hébergement - France*
+
+# Procès-verbal de la réunion du Conseil d’Administration du 16 avril 2015
+
+Le 16 avril 2016 à 17h, le Conseil d’Administration (CA) de Zeste de Savoir s’est réuni dans les locaux de locaux de PRINE - Paris Région Innovation Nord Express, 48 Rue René Clair, 75018 Paris.
+
+Étaient présentes les personnes suivantes :
+
+- Matthieu Bonan
+- Arnaud Calmettes
+- Florent Chapelle (via Hangouts)
+- Baptiste Clavié
+- François Colin
+- Victor Felder (via Hangouts)
+- Christophe Gabard
+- Willy Konguem
+- Augustin Laville (via Hangouts)
+- Adrien Morison (via Hangouts)
+- Gérard Paligot (via Hangouts)
+- David Roux
+- François Thiré
+
+Le CA désigne David Roux en qualité de président et secrétaire de séance.
+
+Le président de séance rappelle que le conseil est appelé à statuer sur l’ordre du jour suivant :
+
+- Élection du Bureau
+- Questions diverses
+
+## 1 ère délibération
+
+Le CA élit à l’unanimité les membres du Bureau :
+
+- Président : Christophe Gabard
+- Trésorier : Matthieu Bonan
+- Secrétaire : David Roux
+- Vice-Président : Arnaud Calmettes
+- Vice-Trésorier : Gautier Szukala
+- Vice-Secrétaire : Augustin Laville
+
+## 2 ème délibération
+
+Le CA refuse la proposition de David Roux d’exclure Sébastien Tuitié de Vaucresson de l’association pour manquements graves et abandon de poste par 1 voix pour, 7 voix contre et 5 votes blancs.
+
+## 3 ème délibération
+
+Le CA refuse la proposition de David Roux d’exclure Christian Dreher de l’association pour manquements graves et abandon de poste par 1 voix pour, 8 voix contre, 4 votes blancs et 1 abstention.
+
+## 4 ème délibération
+
+Il est décidé que le CA devra se réunir prochainement pour valider les nouveaux statuts et la mise à jour du Règlement Intérieur ainsi que pour faire un point sur l’avancée de la récupération des documents et accès relatifs à l’association.
+
+---
+
+Il est dressé le présent procès-verbal de la réunion du Conseil d’Administration de Zeste de Savoir.
+
+*Christophe Gabard - Président de Zeste de Savoir*
+
+*David Roux - Secrétaire de Zeste de Savoir*

--- a/2016/2016-04-16_convoc_AGO.md
+++ b/2016/2016-04-16_convoc_AGO.md
@@ -1,0 +1,30 @@
+*Zeste de Savoir*
+
+*9 rue Jean Yole, Appt 06 - 85260 L'Herbergement*
+
+*Courbevoie, le 31/03/2015*
+
+Madame, Monsieur,
+
+Nous avons l'honneur de vous informer qu'une Assemblée Générale Ordinaire de l'association Zeste de Savoir aura lieu le 16 avril 2016, à 15 heures, dans le bâtiment de PRINE - Paris Région Innovation Nord Express, 48 Rue René Clair, 75018 Paris.
+
+L'ordre du jour sera le suivant :
+
+1. Rapport d'activité de l’association
+2. Bilan moral du Président
+3. Bilan financier du Trésorier
+4. Modification des statuts et du règlement intérieur
+5. Fixation du montant des cotisations
+6. Renouvellement des membres du Conseil d'Administration
+7. Questions diverses
+
+Nous vous rappelons qu'en vertu des dispositions de nos statuts et de notre règlement intérieur :
+
+- Pour avoir le droit de participer à l'assemblée, vous devez être à jour de cotisation à la date
+du 16 avril 2016.
+- Si vous ne pouvez pas assister personnellement à l'assemblée générale, vous pouvez vous y faire représenter par un mandataire. A cet effet, vous trouverez ci-joint un formulaire de procuration que vous voudrez bien, après l'avoir complétée et signée, remettre à votre mandataire et par email au secrétaire de l'association. Toutes les procurations doivent, à fins de comptabilisation, être déposées au plus tard le 15 avril 2016. A défaut, elles ne seront pas prises en compte.
+- Vous pouvez si vous le souhaitez participer à l'assemblée générale par voie électronique. La vidéoconférence se fera via Hangouts de Google. Vous devrez ajouter l'adresse secretaire.zds@gmail.com dans vos contacts pour pouvoir y participer (merci de prévenir par avance pour pouvoir vous inclure dans la vidéoconférence).
+
+Cordialement,
+
+*David Roux, Secrétaire de l’association Zeste de Savoir*

--- a/2017/2017-04-08_PV_AGO.md
+++ b/2017/2017-04-08_PV_AGO.md
@@ -1,0 +1,127 @@
+*Association Zeste de Savoir*
+
+*162 rue Saint-Maur - 75011 Paris - France*
+
+# Procès-verbal de l’Assemblée Générale Ordinaire du 8 avril 2017
+
+Le 8 avril 2017 à 15h, les membres de l’association Zeste de Savoir se sont réunis en Assemblée Générale ordinaire (AGO) chez François Colin – 6 place du 11 novembre 1918, 92300 Levallois-Perret.
+
+Étaient présentes les personnes suivantes (physiquement ou à distance via Skype et Framatalk) :
+
+- Christophe Gabard, Président
+- Matthieu Bonan, Trésorier
+- David Roux, Secrétaire
+- Arnaud Calmettes, Vice-Président
+- Augustin Laville, Vice-Secrétaire
+- Mehdi Benharrats
+- Guillaume Chirache
+- François Colin
+- Baptiste Clavié
+- Hugo Courtecuisse
+- François Dambrine
+- Victor Felder
+- Willy Konguem
+- Victor Michel
+- Gérard Paligot
+- Antoine Rozo
+- François Thiré
+
+Procurations :
+
+- Quentin Gliech a donné procuration à Victor Felder
+- Médéric Munier a donné procuration à François Colin
+- Geoffrey Royer a donné procuration à Arnaud Calmettes
+- Gautier Szukala a donné procuration à Matthieu Bonan
+
+Christophe Gabard préside la séance. David Roux est le secrétaire de séance.
+
+Après les salutations d’usage, le président de séance rappelle que l’Assemblée Générale Ordinaire est appelée à statuer sur l’ordre du jour suivant :
+
+1. Rapport d'activité de l’association
+2. Bilan moral du Président
+3. Bilan financier du Trésorier
+4. Modification des statuts et du règlement intérieur-
+5. Fixation du montant des cotisations
+6. Renouvellement des membres du Conseil d'Administration
+7. Questions diverses
+
+## Bilan moral du Président
+
+Le Président de l’association, Christophe Gabard, nous fait part des avancées des démarches administratives et notamment celles relatives à le reprise en main du compte bancaire de l’association. Le compte est de nouveau accessible et les démarches auprès de la Préfecture sont terminées.
+
+Le Président se félicite de la participation de l’association au Capitole du Libre de Toulouse en novembre 2016 et espère que l’association réitèrera une telle présence à d’autres événements cette année. Il tient tout particulièrement à remercier Nathanaël Jourdane pour son implication dans l’organisation de la présence de l’association au Capitole du Libre.
+
+## Bilan financier
+
+Matthieu Bonan nous présente le bilan financier de l’année passée. Étant en phase de transition, il n’y a pas eu de cotisations pour l’exercice 2016. Le solde du compte de l’association s’élève à 870,25€ auxquels devront se soustraire les remboursements auprès de certains membres des sommes avancées pour un montant de 391.11€.
+
+En restant sur la même infrastructure, il est prévu des dépenses s’élevant à environ 547€ pour 2017. Ce qui, couplé à une provision de 60% en cas d’imprévu au niveau de l’hébergement des serveurs, donne un budget prévisionnel d’environ 900€ pour 2017.
+
+Le Trésorier propose donc une cotisation de 30€ pour cette année. Après discussion, notamment au sujet des étudiants qui ont un budget plus restreints et face au fait que le nombre d’adhérents à l’association augmente, ce montant est révisé à 25€ et adopté à l’unanimité par l’AGO. Il sera soumis au vote du CA pour mise en application officielle.
+
+Dans le futur, la mise en place de deux montants de cotisation sera étudiée. De plus, le Secrétaire rappelle qu’en cas de difficulté de paiement, le CA étudiera chaque cas individuellement et qu’il n’y a donc pas lieu de s’inquiéter.
+
+Le sujet des dons revient sur la table mais cela n’est pas une priorité pour les membres du Bureau.
+
+Le budget devrait rester stable car Victor Felder, responsable technique du site, précise que le dimensionnement des serveurs suffit largement à nos besoins actuels et à moyen terme.
+
+Le Trésorier mentionne aussi le fait qu’une vérification de la police d’assurance de l’association sera effectuée dans les plus brefs délais.
+
+## Rapport d’activité
+
+François Colin présente les chiffres relatifs au site Web Zeste de Savoir. Les chiffres sont bons malgré le creux observé durant l’été 2016. Il est également noté que les membres se connectent plus en semaine que le weekend. La fréquentation a été en hausse entre septembre 2016 et janvier 2017 et s’est stabilisée depuis.
+
+Il semblerait qu’une certaine routine se soit installée au sein de la communauté du site. L’accent devrait être mis sur la publicité en dehors du site car actuellement personne ne parle de nous.
+
+Certains membres, et en particulier Arnaud Calmettes et François Thiré, suggèrent l’organisation de meetups ou de « hackaton – rédacthon ». A ce sujet, Hugo Courtecuisse annonce qu’il va voir avec son employeur s’il est possible de prêter une salle à l’association le temps d’une soirée pour organiser de tels événements communautaires.
+
+L’équipe Communication poursuit à son rythme de croisière. Le rapport d’activité est adopté à l’unanimité.
+
+## Cotisation
+
+Elle sera fixée par le CA comme en se basant sur la proposition de l’AGO de 25€.
+
+## Modification des statuts et du règlement intérieur
+
+Seules de mineures fautes de frappes ainsi que le montant de la cotisation seront ajoutés aux documents officiels de l’association sous contrôle du CA.
+
+Cette proposition est adoptée à l’unanimité.
+
+## Élection du Conseil d’Administration
+
+Après consultation des membres présents, se représentent au Conseil d’Administration les personnes suivantes :
+
+- Matthieu Bonan
+- Arnaud Calmettes
+- Florent Chapelle
+- Baptiste Clavié
+- François Colin
+- Christophe Gabard
+- Willy Konguem
+- Augustin Laville
+- Adrien Morison
+- Gérard Paligot
+- David Roux
+- Gautier Szukala
+- François Thiré
+
+Se présentent également cette année :
+
+- Quentin Gliech
+- Geoffrey Royer
+- Antoine Rozot
+
+Ne se représentent pas :
+
+- Florent Chapelle
+- Victor Felder
+
+L’Assemblée Générale Ordinaire élit à l’unanimité les membres sortants qui se représentent et les nouveaux postulants.
+
+---
+
+Il est dressé le présent procès-verbal de l'Assemblée Générale Ordinaire.
+
+*Christophe Gabard - Président de Zeste de Savoir*
+
+*David Roux - Secrétaire de Zeste de Savoir*

--- a/2017/2017-04-08_PV_RCA.md
+++ b/2017/2017-04-08_PV_RCA.md
@@ -1,0 +1,59 @@
+*Association Zeste de Savoir*
+
+*162 rue Saint-Maur - 75011 Paris - France*
+
+# Procès-verbal de la réunion du Conseil d’Administration du 8 avril 2017
+
+Le 8 avril 2017 à 17h, le Conseil d’Administration (CA) de Zeste de Savoir s’est réuni chez François Colin - 6 place du 11 novembre 1918, 92300 Levallois-Perret.
+
+Étaient présentes les personnes suivantes (physiquement ou à distance via Skype) :
+
+- Matthieu Bonan
+- Arnaud Calmettes
+- Baptiste Clavié
+- François Colin
+- Christophe Gabard
+- Willy Konguem
+- Augustin Laville
+- Gérard Paligot
+- David Roux
+- Antoine Rozo
+- François Thiré
+
+Christophe Gabard préside la séance. David Roux est le secrétaire de séance.
+
+Le président de séance rappelle que le conseil est appelé à statuer sur l’ordre du jour suivant :
+
+1. Élection du Bureau
+2. Questions diverses
+
+## 1ère délibération
+
+Le CA élit à l’unanimité les membres du Bureau :
+
+- **Président** : Christophe Gabard
+- **Trésorier** : Matthieu Bonan
+- **Secrétaire** : David Roux
+- **Vice-Président** : Arnaud Calmettes
+- **Vice-Trésorier** : Gautier Szukala
+- **Vice-Secrétaire** : Augustin Laville
+
+## 2ème délibération
+
+Le CA réaffirme avec force et à l’unanimité sa volonté d’engager l’association dans la participation à plus d’événements cette année mais qu’il faut trouver des volontaires pour mener ce projet à bien. A minima, il faut tenir une liste des événements à jour et la mettre à disposition de la communauté.
+
+## 3ème délibération
+
+Le CA accepte à l’unanimité de se pencher sur le sujet de réinternalisation de certains services (notamment la sauvegarde, le serveur Sentry...).
+
+## 4ème délibération
+
+Il est décidé que le CA devra se pencher sur certaines améliorations du site qui sont assez lourdes et pourquoi pas réitérer l’expérience du projet étudiant de l’année passée qui a été un succès.
+
+---
+
+Il est dressé le présent procès-verbal de la réunion du Conseil d’Administration de Zeste de Savoir.
+
+*Christophe Gabard - Président de Zeste de Savoir*
+
+*David Roux - Secrétaire de Zeste de Savoir*

--- a/README.md
+++ b/README.md
@@ -2,47 +2,94 @@
 
 Ce dépôt répertorie tous les documents publics de l'association Zeste de Savoir.
 
-## Sources de documents
+## Documents généraux
 
-Sont disponibles :
+Nature du document                         | Source                         | Fichier PDF
+-------------------------------------------|------------------------------- | -----------
+Les statuts                                | [lien](statuts.md)             | [lien](https://drive.google.com/open?id=0BzabS14KitJgY3p1MTZ1OTJOcms)
+Le règlement intérieur                     | [lien](reglement-interieur.md) | [lien](https://drive.google.com/open?id=0BzabS14KitJgZm1xMnowbkZHOWc)
+Annonce de publication au journal officiel | -                              | [lien](https://drive.google.com/open?id=0BzabS14KitJgQ0tzX1F1eUdYeGs)
 
- - [Les sources des statuts](statuts.md)
- - [Les sources du règlement intérieur](reglement-interieur.md)
+## Documents relatifs aux assemblées générales et réunions du CA
 
+### 2014
 
-## Documents publics
+Assemblée Générale Constitutive du 15 mars 2014 (création de l'association)
 
-D'autres documents sous format PDF sont disponibles et à disposition des membres hors de ce dépôt :
+Nature du document                         | Source                                | Fichier PDF
+-------------------------------------------|-------------------------------------- | -----------
+Convocation                                | [lien](2014/2014-03-15_convoc_AGC.md) | [lien](https://drive.google.com/open?id=0BzabS14KitJgQkJzRzRYbnRfeWc)
+Procès-verbal                              | [lien](2014/2014-03-15_PV_AGC.md)     | [lien](https://drive.google.com/open?id=0BzabS14KitJgYXl5eW1ZRFQ5NUU)
 
- - [Les statuts](https://drive.google.com/open?id=0BzabS14KitJgY3p1MTZ1OTJOcms)
- - [Le règlement intérieur](https://drive.google.com/open?id=0BzabS14KitJgZm1xMnowbkZHOWc)
- - [L'annonce de publication au journal officiel](https://drive.google.com/open?id=0BzabS14KitJgQ0tzX1F1eUdYeGs)
- - Convocations d'AG:
-    - [AG constitutive](https://drive.google.com/open?id=0BzabS14KitJgQkJzRzRYbnRfeWc) *(15-03-2014)*
-    - [AG ordinaire](https://drive.google.com/open?id=0BzabS14KitJgbG9DYVUyeS1QaGM) *(11-04-2015)*
-    - [AG ordinaire](https://drive.google.com/open?id=0BzabS14KitJgVXlEdHRFSEwxdHM) *(16-04-2016)*
- - Comptes rendus d'AG:
-    - [AG constitutive](https://drive.google.com/open?id=0BzabS14KitJgYXl5eW1ZRFQ5NUU) *(15-03-2014)*
-    - [AG ordinaire](https://drive.google.com/open?id=0BzabS14KitJgQVZyamZjUEtlTms) *(11-04-2015)*
-    - [AG ordinaire](https://drive.google.com/open?id=0BzabS14KitJgcXVqb0Y4R0VyUWM) *(16-04-2016)*
-    - [AG ordinaire](https://drive.google.com/open?id=0B1uBR2hmcLbMaENDQm1ucjVvTk0) *(08-04-2017)*
- - Réunions du CA:
-    - [Réunion du CA - Post AG constitutive](https://drive.google.com/open?id=0BzabS14KitJgUmFtSmQ5UHFFbms) *(15-03-2014)*
-    - [Réunion du CA ordinaire](https://drive.google.com/open?id=0BzabS14KitJgT1RybzJJcnphMWc) *(05-05-2014)*
-    - [Réunion du CA - Post AG ordinaire](https://drive.google.com/open?id=0BzabS14KitJgbS1Lc2tDVEhMZ2M) *(11-04-2015)*
-    - [Réunion du CA - Post AG ordinaire](https://drive.google.com/open?id=0BzabS14KitJgOXZ5c0UwR095Y0E) *(16-04-2016)*
-    - [Réunion du CA - Post AG ordinaire](https://drive.google.com/open?id=0B1uBR2hmcLbMRDhGNm5iUFpKejg) *(08-04-2017)*
+Réunion du Conseil d'Administration du 15 mars 2014 (post AG constitutive)
+
+Nature du document                         | Source                            | Fichier PDF
+-------------------------------------------|---------------------------------- | -----------
+Procès-verbal                              | [lien](2014/2014-03-15_PV_RCA.md) | [lien](https://drive.google.com/open?id=0BzabS14KitJgUmFtSmQ5UHFFbms)
+
+Réunion du Conseil d'Administration du 5 mai 2014
+
+Nature du document                         | Source                            | Fichier PDF
+-------------------------------------------|---------------------------------- | -----------
+Procès-verbal                              | [lien](2014/2014-05-05_PV_RCA.md) | [lien](https://drive.google.com/open?id=0BzabS14KitJgT1RybzJJcnphMWc)
+
+### 2015
+
+Assemblée Générale Ordinaire du 11 avril 2015
+
+Nature du document                         | Source                                | Fichier PDF
+-------------------------------------------|-------------------------------------- | -----------
+Convocation                                | [lien](2015/2015-04-11_convoc_AGO.md) | [lien](https://drive.google.com/open?id=0BzabS14KitJgbG9DYVUyeS1QaGM)
+Procès-verbal                              | [lien](2015/2015-04-11_PV_AGO.md)     | [lien](https://drive.google.com/open?id=0BzabS14KitJgQVZyamZjUEtlTms)
+
+Réunion du Conseil d'Administration du 11 avril 2015 (post AG)
+
+Nature du document                         | Source                            | Fichier PDF
+-------------------------------------------|---------------------------------- | -----------
+Procès-verbal                              | [lien](2015/2015-04-11_PV_RCA.md) | [lien](https://drive.google.com/open?id=0BzabS14KitJgbS1Lc2tDVEhMZ2M)
+
+### 2016
+
+Assemblée Générale Ordinaire du 16 avril 2016
+
+Nature du document                         | Source                                | Fichier PDF
+-------------------------------------------|-------------------------------------- | -----------
+Convocation                                | [lien](2016/2016-04-16_convoc_AGO.md) | [lien](https://drive.google.com/open?id=0BzabS14KitJgVXlEdHRFSEwxdHM)
+Procès-verbal                              | [lien](2016/2016-04-16_PV_AGO.md)     | [lien](https://drive.google.com/open?id=0BzabS14KitJgcXVqb0Y4R0VyUWM)
+
+Réunion du Conseil d'Administration du 16 avril 2016 (post AG)
+
+Nature du document                         | Source                            | Fichier PDF
+-------------------------------------------|---------------------------------- | -----------
+Procès-verbal                              | [lien](2016/2016-04-16_PV_RCA.md) | [lien](https://drive.google.com/open?id=0BzabS14KitJgOXZ5c0UwR095Y0E)
+
+### 2017
+
+Assemblée Générale Ordinaire du 8 avril 2017
+
+Nature du document                         | Source                            | Fichier PDF
+-------------------------------------------|---------------------------------- | -----------
+Convocation                                | -                                 | -
+Procès-verbal                              | [lien](2017/2017-04-08_PV_AGO.md) | [lien](https://drive.google.com/open?id=0B1uBR2hmcLbMaENDQm1ucjVvTk0)
+
+Réunion du Conseil d'Administration du 8 avril 2017 (post AG)
+
+Nature du document                         | Source                            | Fichier PDF
+-------------------------------------------|---------------------------------- | -------------
+Procès-verbal                              | [lien](2017/2017-04-08_PV_RCA.md) |[lien](https://drive.google.com/open?id=0B1uBR2hmcLbMRDhGNm5iUFpKejg)
 
 ## Documents privés
 
-Cette liste repertorie les documents qui n'ont pas été rendu publics mais sont à disposition des membres du bureau de l'association. Selon la section **Documents et services relatif à l'association** du règlement intérieur, *tout membre de l'association peut faire la demande de mise à disposition du public des documents relatifs à l'association. Le conseil d'administration décide alors de cette mise à disposition après avis des membres du bureau.*
+Cette liste repertorie les documents qui n'ont pas été rendu publics mais sont à disposition des membres du bureau de l'association.
+
+Selon la section **Documents et services relatif à l'association** du règlement intérieur, *tout membre de l'association peut faire la demande de mise à disposition du public des documents relatifs à l'association. Le conseil d'administration décide alors de cette mise à disposition après avis des membres du bureau.*
 
 Pour toute demande particulière, contacter l'association à zestedesavoir@gmail.com.
 
  - Déclaration et récépissé de déclaration à la CNIL
  - Note pour les futurs membres du bureau (annotations des démarches à effectuer lors du changement du bureau, comptes et actions à effectuer)
  - Facture et devis:
-  - 2016 / AGECA : Devis AGECA pour la location de la première salle envisagé pour l'AG & Attestation de virement depuis le compte personnel du secretaire 
+  - 2016 / AGECA : Devis AGECA pour la location de la première salle envisagé pour l'AG & Attestation de virement depuis le compte personnel du secretaire
  - AG : Procurations des membres absents
  - Demande de changement en prefecture (2016) :
   - Résumé demande 1
@@ -50,8 +97,8 @@ Pour toute demande particulière, contacter l'association à zestedesavoir@gmail
   - Résumé demande 2
   - Récépissé acceptation changement
  - PV 2ème réunion du CA (*12 Mai 2016*)
- 
+
 -------
 
-Sauf mention contraire, l'ensemble des documents est sous la licence 
+Sauf mention contraire, l'ensemble des documents est sous la licence
 [CC BY 4.0](http://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
Cette PR ajoute les documents publics relatifs aux AG et réunions CA.

Ce sont des conversions des documents pdf provenant du Drive en fichiers markdown.

La page de readme a également été mise à jour en conséquence et structurée en années afin d'améliorer la lisibilité.